### PR TITLE
Fix broken links to dbt Getting Started tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This dbt project is database agnostic, requires no data sources, and focuses on 
 
 ## Create dbt Project
 
-If you're just getting started learning dbt, then you may want to look at Getting Started with [dbt Core](https://docs.getdbt.com/tutorial/learning-more/getting-started-dbt-core) or [dbt Cloud](https://docs.getdbt.com/tutorial/getting-started)
+If you're just getting started learning dbt, then you may want to look at Getting Started with [dbt Core](https://docs.getdbt.com/docs/get-started/getting-started-dbt-core) or [dbt Cloud](https://docs.getdbt.com/docs/get-started/getting-started/set-up-dbt-cloud)
 
 
 ### Choose a data warehouse


### PR DESCRIPTION
Fixed broken links to the Getting Started with dbt tutorials.

## Before Fix

When trying to access the first link - "Getting Started with dbt Core" - this error page is displayed:

![image](https://user-images.githubusercontent.com/5227894/209927905-db5ee84d-bc87-4923-8dc0-e717bc0db406.png)

For the second link that I changed - "Getting Started with dbt Cloud" - there is no error actually, but rather it redirects to the parent page of the two tutorials. I think it would be better to open the actual "dbt Cloud" page instead, so I fixed that link too.

![image](https://user-images.githubusercontent.com/5227894/209928311-eca5dcda-2389-4d25-805c-2ed4a0ddb95c.png)

## After Fix

Getting Started with dbt Core:
![image](https://user-images.githubusercontent.com/5227894/209928738-2941c85f-6da3-49c1-ac0e-b1033a3c4303.png)

Getting Started with dbt Cloud:
![image](https://user-images.githubusercontent.com/5227894/209928896-64e50b32-26e9-43e5-88cb-cb4a7811d53e.png)

