### PR TITLE
add recent and first order dates to customer

### DIFF
--- a/models/marts/dim_customer.sql
+++ b/models/marts/dim_customer.sql
@@ -9,5 +9,7 @@ select
     longitude,
     contact_name,
     phone,
-    email
+    email,
+    recent_order_date,
+    first_order_date
 from {{ ref('stg_customer') }}

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -210,6 +210,16 @@ models:
         data_type: text
         meta:
           label: Email
+      - name: recent_order_date
+        data_type: date
+        description: "Date of the most recent order placed by the customer, used for customer relationship management"
+        meta:
+          label: Recent Order Date
+      - name: first_order_date
+        data_type: date
+        description: "Date of the first order placed by the customer, used for historical analysis"
+        meta:
+          label: First Order Date
 
   - name: dim_order
     description: "{{ doc('dim_order') }}"

--- a/models/staging/stg_customer.sql
+++ b/models/staging/stg_customer.sql
@@ -10,5 +10,17 @@ select distinct
     {{ split_part('latlng', "','", 2) }} longitude,
     contact_name,
     phone,
-    email
-from {{ source('salesforce', 'stg_sales_data') }}
+    email,
+    --slowly changing dimension Type 1, using subquery
+    (
+        select max(order_date)
+        from {{ source('salesforce', 'stg_sales_data') }} as b
+        where a.customer_code = b.customer_code
+    ) as recent_order_date,
+    --slowly changing dimension Type 0, using subquery
+    (
+        select min(order_date)
+        from {{ source('salesforce', 'stg_sales_data') }} as b
+        where a.customer_code = b.customer_code
+    ) as first_order_date
+from {{ source('salesforce', 'stg_sales_data') }} as a


### PR DESCRIPTION
This PR adds `recent_order_date` and `first_order_date` to `dim_customer`, with the same logic as the columns in `dim_product`.